### PR TITLE
Disable mod_deflate

### DIFF
--- a/htdocs/include/ticketr.php
+++ b/htdocs/include/ticketr.php
@@ -58,6 +58,7 @@ if(!$complete)
 header("Content-Length: $size");
 session_write_close();
 ob_end_flush();
+apache_setenv('no-gzip', '1');
 
 // contents
 $left = $size;


### PR DESCRIPTION
If the Apache server config has mod_deflate output compression enabled, chunked
transfer encoding is used and the Content-Length header is suppressed.

This results in the browser not knowing the download size and not being able to
display download progress.

So here we just disable mod_deflate in case it is active.  If mod_deflate is
not active, setting this environment variable doesn't hurt.

See the comments:
- http://de.php.net/manual/en/function.flush.php
- http://php.net/manual/en/function.readfile.php
- http://php.net/manual/en/function.apache-setenv.php
