### PR TITLE
Added a simple password prompt to avoid storing passwords in plain text

### DIFF
--- a/client/dl-cli.py
+++ b/client/dl-cli.py
@@ -131,6 +131,7 @@ def die(descr, code=1):
     print >> sys.stderr, sys.argv[0] + ": " + descr
     exit(code)
 
+
 def main():
     parser = argparse.ArgumentParser(description="Upload a file to DL", epilog=DL_AGENT)
     parser.add_argument('-r', metavar="file", dest="rc",


### PR DESCRIPTION
Currently, the password of the user must be stored in the `~/.dl.rc` file in plaintext. While I understand that this can be useful in order to automate tasks easily, it really isn't very secure at all.

I've added a simple check in - if the password is not supplied as part of the config file, `getpass` is used to prompt the user for their password. This remains backwards compatible with the current way of doing things, but allows a user to avoid having to hard code their password in the config file.
