### PR TITLE
Add configurable prefix to subject of email notifications.

### DIFF
--- a/htdocs/include/config.php.dist
+++ b/htdocs/include/config.php.dist
@@ -33,6 +33,10 @@ $defaultGrantTotalDays = 365;
 $defaultGrantLastUlDays = 30;
 $defaultGrantMaxUl = 0;
 
+/**
+ * Email settings
+ */
+$emailSubjectPrefix = "[DL File Service] " ;
 
 /*
  * Advanced settings (defaults commented)

--- a/htdocs/include/msg.php
+++ b/htdocs/include/msg.php
@@ -3,7 +3,8 @@
 
 function msgTicketCreate($DATA, &$subject, &$body)
 {
-  $subject = sprintf(T_("[dl] download link to %s"), $DATA['name']);
+  global $emailSubjectPrefix;
+  $subject = sprintf(T_("{$emailSubjectPrefix}download link to %s"), $DATA['name']);
   if(!empty($DATA['cmt']))
     $body .= T_("Ticket comment:") . " " . $DATA['cmt'] . ".\n\n";
   $body .= T_("URL:") . " " . ticketUrl($DATA) . "\n";
@@ -14,8 +15,8 @@ function msgTicketCreate($DATA, &$subject, &$body)
 
 function msgTicketDownload($DATA, &$subject, &$body)
 {
-  global $masterPath;
-  $subject = sprintf(T_("[dl] ticket %s download notification"), ticketStr($DATA));
+  global $masterPath, $emailSubjectPrefix;
+  $subject = sprintf(T_("{$emailSubjectPrefix}ticket %s download notification"), ticketStr($DATA));
   $body = sprintf(T_("The ticket %s was downloaded by %s from %s"),
       ticketStr($DATA), $_SERVER["REMOTE_ADDR"], $masterPath);
 }
@@ -23,8 +24,8 @@ function msgTicketDownload($DATA, &$subject, &$body)
 
 function msgTicketPurge($DATA, &$subject, &$body)
 {
-  global $masterPath;
-  $subject = sprintf(T_("[dl] ticket %s purge notification"), ticketStr($DATA));
+  global $masterPath, $emailSubjectPrefix;
+  $subject = sprintf(T_("{$emailSubjectPrefix}ticket %s purge notification"), ticketStr($DATA));
   $body = sprintf(T_("The ticket %s was purged manually after %d downloads from %s"),
       ticketStr($DATA), $DATA["downloads"], $masterPath);
 }
@@ -32,8 +33,8 @@ function msgTicketPurge($DATA, &$subject, &$body)
 
 function msgTicketExpire($DATA, &$subject, &$body)
 {
-  global $masterPath;
-  $subject = sprintf(T_("[dl] ticket %s purge notification"), ticketStr($DATA));
+  global $masterPath, $emailSubjectPrefix;
+  $subject = sprintf(T_("{$emailSubjectPrefix}ticket %s purge notification"), ticketStr($DATA));
   $body = sprintf(T_("The ticket %s expired automatically after %d downloads from %s"),
       ticketStr($DATA), $DATA["downloads"], $masterPath);
 }
@@ -41,7 +42,8 @@ function msgTicketExpire($DATA, &$subject, &$body)
 
 function msgGrantCreate($DATA, &$subject, &$body)
 {
-  $subject = T_("[dl] upload grant link");
+  global $emailSubjectPrefix;
+  $subject = T_("{$emailSubjectPrefix}upload grant link");
   if(!empty($DATA['cmt']))
     $body .= T_("Grant comment:") . " " . $DATA['cmt'] . ".\n\n";
   $body .= T_("URL:") . " " . grantUrl($DATA) . "\n";
@@ -52,24 +54,24 @@ function msgGrantCreate($DATA, &$subject, &$body)
 
 function msgGrantPurge($DATA, &$subject, &$body)
 {
-  global $masterPath;
-  $subject = sprintf(T_("[dl] grant %s purge notification"), grantStr($DATA));
+  global $masterPath, $emailSubjectPrefix;
+  $subject = sprintf(T_("{$emailSubjectPrefix}grant %s purge notification"), grantStr($DATA));
   $body = sprintf(T_("The grant %s was purged manually from %s"), grantStr($DATA), $masterPath);
 }
 
 
 function msgGrantExpire($DATA, &$subject, &$body)
 {
-  global $masterPath;
-  $subject = sprintf(T_("[dl] grant %s purge notification"), grantStr($DATA));
+  global $masterPath, $emailSubjectPrefix;
+  $subject = sprintf(T_("{$emailSubjectPrefix}grant %s purge notification"), grantStr($DATA));
   $body = sprintf(T_("The grant %s expired automatically from %s"), grantStr($DATA), $masterPath);
 }
 
 
 function msgGrantUse($GRANT, $TICKET, &$subject, &$body)
 {
-  global $dateFmtShort;
-  $subject = sprintf(T_("[dl] download link for grant %s"), grantStr($GRANT));
+  global $dateFmtShort, $emailSubjectPrefix;
+  $subject = sprintf(T_("{$emailSubjectPrefix}download link for grant %s"), grantStr($GRANT));
   $body = sprintf(T_("Your grant %s has been used on %s by %s."),
 		  grantStr($GRANT), date($dateFmtShort, $GRANT["time"]),
 		  $_SERVER["REMOTE_ADDR"]) . "\n";


### PR DESCRIPTION
A small tweak to allow a configurable email subject prefix for notifications sent out by dl.
Ref #49 