### PR TITLE
Quote tables and columns name

### DIFF
--- a/htdocs/include/scripts/dbupgrade.php
+++ b/htdocs/include/scripts/dbupgrade.php
@@ -12,15 +12,15 @@ require_once("dbfuncs.php");
 connectDB(false);
 
 // fetch current db release
-$sql = "SELECT value FROM config WHERE name = 'version'";
+$sql = "SELECT \"value\" FROM \"config\" WHERE \"name\" = 'version'";
 $version = @$db->query($sql)->fetchColumn();
 
 if(!$version || version_compare($version, "0.4", "<"))
 {
   echo "upgrading 0.3 => 0.4 ...\n";
 
-  $db->exec("CREATE TABLE config (name VARCHAR PRIMARY KEY, value VARCHAR)");
-  $db->exec("INSERT INTO config VALUES('version', '0.4')");
+  $db->exec("CREATE TABLE \"config\" (\"name\" VARCHAR PRIMARY KEY, \"value\" VARCHAR)");
+  $db->exec("INSERT INTO \"config\" VALUES('version', '0.4')");
 
   $version = "0.4";
 }
@@ -29,16 +29,16 @@ if(version_compare($version, "0.10", "<"))
 {
   echo "upgrading 0.4 => 0.10 ...\n";
 
-  $db->exec("ALTER TABLE ticket ADD sent_email VARCHAR(1023)");
-  $db->exec("ALTER TABLE ticket ADD locale VARCHAR(255)");
+  $db->exec("ALTER TABLE \"ticket\" ADD \"sent_email\" VARCHAR(1023)");
+  $db->exec("ALTER TABLE \"ticket\" ADD \"locale\" VARCHAR(255)");
   if($db->driver() != "sqlite")
   {
     // not supported by sqlite, it will leave the column
-    $db->exec("ALTER TABLE ticket DROP expire_last");
+    $db->exec("ALTER TABLE \"ticket\" DROP \"expire_last\"");
   }
-  $db->exec("ALTER TABLE grant ADD sent_email VARCHAR(1023)");
-  $db->exec("ALTER TABLE grant ADD locale VARCHAR(255)");
-  $db->exec("UPDATE config SET value = '0.10' WHERE name = 'version'");
+  $db->exec("ALTER TABLE \"grant\" ADD \"sent_email\" VARCHAR(1023)");
+  $db->exec("ALTER TABLE \"grant\" ADD \"locale\" VARCHAR(255)");
+  $db->exec("UPDATE \"config\" SET \"value\" = '0.10' WHERE \"name\" = 'version'");
 
   $version = "0.10";
 }
@@ -47,10 +47,10 @@ if(version_compare($version, "0.11", "<"))
 {
   echo "upgrading 0.10 => 0.11 ...\n";
 
-  $db->exec("ALTER TABLE user ADD pass_ph VARCHAR(60)");
-  $db->exec("ALTER TABLE ticket ADD pass_ph VARCHAR(60)");
-  $db->exec("ALTER TABLE grant ADD pass_ph VARCHAR(60)");
-  $db->exec("UPDATE config SET value = '0.11' WHERE name = 'version'");
+  $db->exec("ALTER TABLE \"user\" ADD \"pass_ph\" VARCHAR(60)");
+  $db->exec("ALTER TABLE \"ticket\" ADD \"pass_ph\" VARCHAR(60)");
+  $db->exec("ALTER TABLE \"grant\" ADD \"pass_ph\" VARCHAR(60)");
+  $db->exec("UPDATE \"config\" SET \"value\" = '0.11' WHERE \"name\" = 'version'");
 
   $version = "0.11";
 }
@@ -59,8 +59,8 @@ if(version_compare($version, "0.12", "<"))
 {
   echo "upgrading 0.11 => 0.12 ...\n";
 
-  $db->exec("ALTER TABLE user ADD email VARCHAR(255)");
-  $db->exec("UPDATE config SET value = '0.12' WHERE name = 'version'");
+  $db->exec("ALTER TABLE \"user\" ADD \"email\" VARCHAR(255)");
+  $db->exec("UPDATE \"config\" SET \"value\" = '0.12' WHERE \"name\" = 'version'");
 
   $version = "0.12";
 }
@@ -73,47 +73,47 @@ if(version_compare($version, "0.18", "<"))
   if($db->driver() != "sqlite")
   {
     // not supported by sqlite, it will leave the column
-    $db->exec("ALTER TABLE grant DROP downloads");
+    $db->exec("ALTER TABLE \"grant\" DROP \"downloads\"");
   }
 
   // shift expire times to be relative
-  $db->exec("UPDATE ticket SET expire = expire - time");
-  $db->exec("UPDATE grant SET expire = expire - time");
-  $db->exec("UPDATE grant SET grant_expire = grant_expire - time");
+  $db->exec("UPDATE \"ticket\" SET \"expire\" = expire - time");
+  $db->exec("UPDATE \"grant\" SET \"expire\" = expire - time");
+  $db->exec("UPDATE \"grant\" SET \"grant_expire\" = grant_expire - time");
 
   // track grant usage
-  $db->exec("ALTER TABLE ticket ADD from_grant CHAR(32)");
+  $db->exec("ALTER TABLE \"ticket\" ADD \"from_grant\" CHAR(32)");
 
   // password policy
-  $db->exec("ALTER TABLE ticket ADD pass_send BOOLEAN NOT NULL DEFAULT 0");
-  $db->exec("ALTER TABLE grant ADD pass_send BOOLEAN NOT NULL DEFAULT 0");
+  $db->exec("ALTER TABLE \"ticket\" ADD \"pass_send\" BOOLEAN NOT NULL DEFAULT 0");
+  $db->exec("ALTER TABLE \"grant\" ADD \"pass_send\" BOOLEAN NOT NULL DEFAULT 0");
 
   // multiple grant re-use
-  $db->exec("ALTER TABLE grant ADD grant_last_time INTEGER");
-  $db->exec("ALTER TABLE grant ADD grant_expire_uln INTEGER");
-  $db->exec("ALTER TABLE grant ADD uploads INTEGER NOT NULL DEFAULT 0");
-  $db->exec("ALTER TABLE grant ADD last_stamp INTEGER");
-  $db->exec("DROP INDEX i_grant");
-  $db->exec('CREATE INDEX i_grant on "grant" ( grant_expire, grant_expire_uln, uploads )');
+  $db->exec("ALTER TABLE \"grant\" ADD \"grant_last_time\" INTEGER");
+  $db->exec("ALTER TABLE \"grant\" ADD \"grant_expire_uln\" INTEGER");
+  $db->exec("ALTER TABLE \"grant\" ADD \"uploads\" INTEGER NOT NULL DEFAULT 0");
+  $db->exec("ALTER TABLE \"grant\" ADD \"last_stamp\" INTEGER");
+  $db->exec("DROP INDEX \"i_grant\" ON \"grant\"");
+  $db->exec("CREATE INDEX \"i_grant\" on \"grant\" ( \"grant_expire\", \"grant_expire_uln\", \"uploads\" )");
 
   // match previous defaults
-  $db->exec("UPDATE ticket SET pass_send = 1");
-  $db->exec("UPDATE grant SET pass_send = 1");
-  $db->exec("UPDATE grant SET grant_expire_uln = 1");
+  $db->exec("UPDATE \"ticket\" SET \"pass_send\" = 1");
+  $db->exec("UPDATE \"grant\" SET \"pass_send\" = 1");
+  $db->exec("UPDATE \"grant\" SET \"grant_expire_uln\" = 1");
 
   // Allow size >2GB
-  switch($driver)
+  switch($db->driver())
   {
   case "mysql":
-    $db->exec("ALTER TABLE ticket MODIFY size BIGINT NOT NULL");
+    $db->exec("ALTER TABLE \"ticket\" MODIFY \"size\" BIGINT NOT NULL");
     break;
 
   case "pgsql":
-    $db->exec("ALTER TABLE ticket ALTER COLUMN size TYPE BIGINT");
+    $db->exec("ALTER TABLE \"ticket\" ALTER COLUMN \"size\" TYPE BIGINT");
     break;
   }
 
-  $db->exec("UPDATE config SET value = '0.18' WHERE name = 'version'");
+  $db->exec("UPDATE \"config\" SET \"value\" = '0.18' WHERE \"name\" = 'version'");
   $version = "0.18";
 }
 


### PR DESCRIPTION
Fix #57
Also fix another small error $driver -> $db->driver

Not all the tables and columns names were having problems, only grant, but it's safer to quote everything. There was another error on:

DROP INDEX \"i_grant\"

changed into

DROP INDEX \"i_grant\" ON \"grant\"

(I guess PostgreSQL was also affected)

I haven't tested on PostgreSQL, or SQLite, but double quotes should work everywhere as it's the standard.