### PR TITLE
Quote grant table name

### DIFF
--- a/htdocs/include/scripts/dbupgrade.php
+++ b/htdocs/include/scripts/dbupgrade.php
@@ -36,8 +36,8 @@ if(version_compare($version, "0.10", "<"))
     // not supported by sqlite, it will leave the column
     $db->exec("ALTER TABLE ticket DROP expire_last");
   }
-  $db->exec("ALTER TABLE grant ADD sent_email VARCHAR(1023)");
-  $db->exec("ALTER TABLE grant ADD locale VARCHAR(255)");
+  $db->exec("ALTER TABLE \"grant\" ADD sent_email VARCHAR(1023)");
+  $db->exec("ALTER TABLE \"grant\" ADD locale VARCHAR(255)");
   $db->exec("UPDATE config SET value = '0.10' WHERE name = 'version'");
 
   $version = "0.10";
@@ -49,7 +49,7 @@ if(version_compare($version, "0.11", "<"))
 
   $db->exec("ALTER TABLE user ADD pass_ph VARCHAR(60)");
   $db->exec("ALTER TABLE ticket ADD pass_ph VARCHAR(60)");
-  $db->exec("ALTER TABLE grant ADD pass_ph VARCHAR(60)");
+  $db->exec("ALTER TABLE \"grant\" ADD pass_ph VARCHAR(60)");
   $db->exec("UPDATE config SET value = '0.11' WHERE name = 'version'");
 
   $version = "0.11";
@@ -73,33 +73,33 @@ if(version_compare($version, "0.18", "<"))
   if($db->driver() != "sqlite")
   {
     // not supported by sqlite, it will leave the column
-    $db->exec("ALTER TABLE grant DROP downloads");
+    $db->exec("ALTER TABLE \"grant\" DROP downloads");
   }
 
   // shift expire times to be relative
   $db->exec("UPDATE ticket SET expire = expire - time");
-  $db->exec("UPDATE grant SET expire = expire - time");
-  $db->exec("UPDATE grant SET grant_expire = grant_expire - time");
+  $db->exec("UPDATE \"grant\" SET expire = expire - time");
+  $db->exec("UPDATE \"grant\" SET grant_expire = grant_expire - time");
 
   // track grant usage
   $db->exec("ALTER TABLE ticket ADD from_grant CHAR(32)");
 
   // password policy
   $db->exec("ALTER TABLE ticket ADD pass_send BOOLEAN NOT NULL DEFAULT 0");
-  $db->exec("ALTER TABLE grant ADD pass_send BOOLEAN NOT NULL DEFAULT 0");
+  $db->exec("ALTER TABLE \"grant\" ADD pass_send BOOLEAN NOT NULL DEFAULT 0");
 
   // multiple grant re-use
-  $db->exec("ALTER TABLE grant ADD grant_last_time INTEGER");
-  $db->exec("ALTER TABLE grant ADD grant_expire_uln INTEGER");
-  $db->exec("ALTER TABLE grant ADD uploads INTEGER NOT NULL DEFAULT 0");
-  $db->exec("ALTER TABLE grant ADD last_stamp INTEGER");
-  $db->exec("DROP INDEX i_grant");
-  $db->exec('CREATE INDEX i_grant on "grant" ( grant_expire, grant_expire_uln, uploads )');
+  $db->exec("ALTER TABLE \"grant\" ADD grant_last_time INTEGER");
+  $db->exec("ALTER TABLE \"grant\" ADD grant_expire_uln INTEGER");
+  $db->exec("ALTER TABLE \"grant\" ADD uploads INTEGER NOT NULL DEFAULT 0");
+  $db->exec("ALTER TABLE \"grant\" ADD last_stamp INTEGER");
+  $db->exec("DROP INDEX i_grant ON \"grant\"");
+  $db->exec("CREATE INDEX i_grant on \"grant\" ( grant_expire, grant_expire_uln, uploads )");
 
   // match previous defaults
   $db->exec("UPDATE ticket SET pass_send = 1");
-  $db->exec("UPDATE grant SET pass_send = 1");
-  $db->exec("UPDATE grant SET grant_expire_uln = 1");
+  $db->exec("UPDATE \"grant\" SET pass_send = 1");
+  $db->exec("UPDATE \"grant\" SET grant_expire_uln = 1");
 
   // Allow size >2GB
   switch($driver)


### PR DESCRIPTION
Fix #57

As requested. Only the grant table name is quoted here. Tested on MySQL. Still the missing ON \"grant\" on the DROP INDEX command though.